### PR TITLE
Implement CLI map mode

### DIFF
--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Client\Client.csproj" />
+    <ProjectReference Include="..\Map\Map.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
     <PackageReference Include="ObjectDumper.NET" Version="3.0.20251.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CLI/Command/MapCommand.cs
+++ b/CLI/Command/MapCommand.cs
@@ -1,0 +1,28 @@
+﻿using Map.Model;
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CLI.Command
+{
+    public class MapCommand
+    {
+        public static System.CommandLine.Command Build()
+        {
+            var command = new System.CommandLine.Command(
+                "map",
+                "地図を生成します"
+                )
+            {
+               UserquakeSubCommand.Build(),
+               // QuakeSubCommand.Build(),
+            };
+
+            return command;
+        }
+    }
+}

--- a/CLI/Command/MapCommand.cs
+++ b/CLI/Command/MapCommand.cs
@@ -18,8 +18,8 @@ namespace CLI.Command
                 "地図を生成します"
                 )
             {
+               QuakeSubCommand.Build(),
                UserquakeSubCommand.Build(),
-               // QuakeSubCommand.Build(),
             };
 
             return command;

--- a/CLI/Command/QuakeSubCommand.cs
+++ b/CLI/Command/QuakeSubCommand.cs
@@ -1,0 +1,76 @@
+﻿using Map.Controller;
+using Map.Model;
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CLI.Command
+{
+    public class QuakeSubCommand
+    {
+        public static System.CommandLine.Command Build()
+        {
+            var command = new System.CommandLine.Command(
+                "quake",
+                "地震情報の地図を生成します"
+                )
+            {
+                new Option<string>("--output", () => "output.png"),
+                new Option<bool>("--trim", () => true),
+                new Option<MapType>("--map-type", () => MapType.JAPAN_1024),
+                new Option<double?>("--latitude"),
+                new Option<double?>("--longitude"),
+                new Option<string[]>(new[]{ "-p", "--pref", "--prefecture" }, () => Array.Empty<string>()),
+                new Option<string[]>(new[]{ "-n", "--name" }, () => Array.Empty<string>()),
+                new Option<int[]>(new[]{ "-s", "--scale" }, () => Array.Empty<int>()),
+            };
+
+            command.Handler = CommandHandler.Create<QuakeOptions>(QuakeHandler);
+
+            return command;
+        }
+
+        public class QuakeOptions
+        {
+            public string Output { get; set; }
+            public bool Trim { get; set; }
+            public MapType MapType { get; set; }
+            public double? Latitude { get; set; }
+            public double? Longitude { get; set; }
+            public string[] Prefecture { get; set; }
+            public string[] Name { get; set; }
+            public int[] Scale { get; set; }
+        }
+
+        private static void QuakeHandler(QuakeOptions options)
+        {
+            if (options.Prefecture.Length != options.Name.Length || options.Name.Length != options.Scale.Length)
+            {
+                Console.Error.WriteLine("The number of elements in Prefecture (--prefecture), Name (--name) and Scale (--scale) must be the same.");
+                return;
+            }
+
+            var hypocenter = (options.Latitude.HasValue && options.Longitude.HasValue) ? new GeoCoordinate(options.Latitude.Value, options.Longitude.Value) : null;
+            var observationPoints = options.Prefecture.Select((prefecture, index) => new ObservationPoint(prefecture, options.Name[index], options.Scale[index])).ToArray();
+
+            var drawer = new MapDrawer()
+            {
+                MapType = options.MapType,
+                Trim = options.Trim,
+                Hypocenter = hypocenter,
+                ObservationPoints = observationPoints,
+            };
+
+            var png = drawer.DrawAsPng();
+            using var file = File.OpenWrite(options.Output);
+            png.CopyTo(file);
+            file.Close();
+            png.Close();
+        }
+    }
+}

--- a/CLI/Command/QuakeSubCommand.cs
+++ b/CLI/Command/QuakeSubCommand.cs
@@ -55,6 +55,18 @@ namespace CLI.Command
                 return;
             }
 
+            if (options.Latitude.HasValue != options.Longitude.HasValue)
+            {
+                Console.Error.WriteLine("Latitude (--latitude) and Longitude (--longitude) must be specified at the same time.");
+                return;
+            }
+
+            if (!options.Latitude.HasValue && options.Prefecture.Length <= 0)
+            {
+                Console.Error.WriteLine("Please specify the hypocenter (--latitude and --longitude) or observation points (-p, -n and -s).");
+                return;
+            }
+
             var hypocenter = (options.Latitude.HasValue && options.Longitude.HasValue) ? new GeoCoordinate(options.Latitude.Value, options.Longitude.Value) : null;
             var observationPoints = options.Prefecture.Select((prefecture, index) => new ObservationPoint(prefecture, options.Name[index], options.Scale[index])).ToArray();
 

--- a/CLI/Command/UserquakeSubCommand.cs
+++ b/CLI/Command/UserquakeSubCommand.cs
@@ -1,0 +1,69 @@
+﻿using Map.Controller;
+using Map.Model;
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CLI.Command
+{
+    public class UserquakeSubCommand
+    {
+        public static System.CommandLine.Command Build()
+        {
+            var command = new System.CommandLine.Command(
+                "userquake",
+                "地震感知情報の地図を生成します"
+                )
+            {
+                new Option<string>("--output", () => "output.png"),
+                new Option<bool>("--trim", () => true),
+                new Option<MapType>("--map-type", () => MapType.JAPAN_1024),
+                new Option<string[]>("--areacode") { IsRequired = true },
+                new Option<double[]>("--confidence") { IsRequired = true },
+            };
+
+            command.Handler = CommandHandler.Create<UserquakeOptions>(UserquakeHandler);
+
+            return command;
+        }
+
+        public class UserquakeOptions
+        {
+            public string Output { get; set; }
+            public bool Trim { get; set; }
+            public MapType MapType { get; set; }
+            public string[] Areacode { get; set; }
+            public double[] Confidence { get; set; }
+        }
+
+        private static void UserquakeHandler(UserquakeOptions options)
+        {
+            if (options.Areacode.Length != options.Confidence.Length)
+            {
+                Console.Error.WriteLine("The number of elements in Areacode (--areacode) and Confidence (--confidence) must be the same.");
+                return;
+            }
+
+            var userquakePoints = options.Areacode.Select((areacode, index) => new UserquakePoint(areacode, options.Confidence[index])).ToArray();
+
+            var drawer = new MapDrawer()
+            {
+                MapType = options.MapType,
+                Trim = options.Trim,
+                UserquakePoints = userquakePoints,
+            };
+
+            var png = drawer.DrawAsPng();
+            using var file = File.OpenWrite(options.Output);
+            png.CopyTo(file);
+            file.Close();
+            png.Close();
+        }
+
+    }
+}

--- a/CLI/Command/UserquakeSubCommand.cs
+++ b/CLI/Command/UserquakeSubCommand.cs
@@ -23,8 +23,8 @@ namespace CLI.Command
                 new Option<string>("--output", () => "output.png"),
                 new Option<bool>("--trim", () => true),
                 new Option<MapType>("--map-type", () => MapType.JAPAN_1024),
-                new Option<string[]>("--areacode") { IsRequired = true },
-                new Option<double[]>("--confidence") { IsRequired = true },
+                new Option<string[]>(new[]{ "-a", "--areacode" }) { IsRequired = true },
+                new Option<double[]>(new[]{ "-c", "--confidence" }) { IsRequired = true },
             };
 
             command.Handler = CommandHandler.Create<UserquakeOptions>(UserquakeHandler);

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -1,4 +1,6 @@
-﻿using CLI.Observers;
+﻿using CLI.Command;
+using CLI.Command;
+using CLI.Observers;
 
 using Client.App;
 
@@ -16,6 +18,7 @@ namespace CLI
         {
             var root = new RootCommand()
             {
+                MapCommand.Build(),
                 new System.CommandLine.Command("legacy", "これまでの Observers CLI を起動します")
                 {
                     Handler = CommandHandler.Create(() =>

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -5,12 +5,30 @@ using Client.App;
 using log4net.Config;
 
 using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
 
 namespace CLI
 {
     class Program
     {
-        static void Main(string[] args)
+        static int Main(string[] args)
+        {
+            var root = new RootCommand()
+            {
+                new System.CommandLine.Command("legacy", "これまでの Observers CLI を起動します")
+                {
+                    Handler = CommandHandler.Create(() =>
+                    {
+                        GrcpMain();
+                    })
+                },
+            };
+
+            return root.InvokeAsync(args).Result;
+        }
+
+       static void GrcpMain()
         {
             BasicConfigurator.Configure();
 


### PR DESCRIPTION
Examples:

```
epsp-peer-cs> .\CLI\bin\Debug\net5.0\CLI  map quake -p 石川県 -n 石川県能登 -s 30 --map-type JAPAN_4096 --output out_quake.png
```

![out_quake](https://user-images.githubusercontent.com/1283492/132519742-59dc4367-f032-4b6a-97ee-2e0e94a1741f.png)

```
epsp-peer-cs> .\CLI\bin\Debug\net5.0\CLI  map userquake -a 250 -c 0.3 -a 270 -c 0.15 -a 275 -c 0.05 --map-type JAPAN_4096 --output out_userquake.png
```

![out_userquake](https://user-images.githubusercontent.com/1283492/132520111-901609ba-1395-4b8b-a21b-a2316efac57f.png)

```
epsp-peer-cs> .\CLI\bin\Debug\net5.0\CLI  map quake --latitude 35.4 --longitude 136.3 --pref 滋賀県 --name 長浜市公園町 --scale 10 --pref 滋賀県 --name 長浜市落合町 --scale 10 --map-type JAPAN_8192 --output out_quake.png
```

![out_quake](https://user-images.githubusercontent.com/1283492/132520774-37bf670f-af64-454d-8997-8d2d17a8116a.png)