### PR TITLE
Support reading observation points (areas) from file

### DIFF
--- a/CLI/Command/UserquakeSubCommand.cs
+++ b/CLI/Command/UserquakeSubCommand.cs
@@ -23,8 +23,9 @@ namespace CLI.Command
                 new Option<string>("--output", () => "output.png"),
                 new Option<bool>("--trim", () => true),
                 new Option<MapType>("--map-type", () => MapType.JAPAN_1024),
-                new Option<string[]>(new[]{ "-a", "--areacode" }) { IsRequired = true },
-                new Option<double[]>(new[]{ "-c", "--confidence" }) { IsRequired = true },
+                new Option<string[]>(new[]{ "-a", "--areacode" }, () => Array.Empty<string>()),
+                new Option<double[]>(new[]{ "-c", "--confidence" }, () => Array.Empty<double>()),
+                new Option<string>("--confidences-file"),
             };
 
             command.Handler = CommandHandler.Create<UserquakeOptions>(UserquakeHandler);
@@ -39,6 +40,7 @@ namespace CLI.Command
             public MapType MapType { get; set; }
             public string[] Areacode { get; set; }
             public double[] Confidence { get; set; }
+            public string ConfidencesFile { get; set; }
         }
 
         private static void UserquakeHandler(UserquakeOptions options)
@@ -50,6 +52,10 @@ namespace CLI.Command
             }
 
             var userquakePoints = options.Areacode.Select((areacode, index) => new UserquakePoint(areacode, options.Confidence[index])).ToArray();
+            if (options.ConfidencesFile != null)
+            {
+                userquakePoints = File.ReadAllLines(options.ConfidencesFile).Select((line) => line.Split(',')).Select((items) => new UserquakePoint(items[0], double.Parse(items[1]))).ToArray();
+            }
 
             var drawer = new MapDrawer()
             {


### PR DESCRIPTION
Examples:

```
epsp-peer-cs> get-content -Encoding UTF8 .\quake_example1.txt
石川県,石川県能登,30
滋賀県,長浜市公園町,10
滋賀県,長浜市落合町,10
epsp-peer-cs> .\CLI\bin\Debug\net5.0\CLI map quake --latitude 35.4 --longitude 136.3 --points-file .\quake_example1.txt --map-type JAPAN_4096
```

![output](https://user-images.githubusercontent.com/1283492/132971090-f7579edf-dd68-4bfa-b794-6357a48ae13e.png)

```
epsp-peer-cs> get-content -Encoding UTF8 .\userquake_example1.txt
250,0.3
270,0.15
275,0.05
epsp-peer-cs> .\CLI\bin\Debug\net5.0\CLI map userquake --confidences-file .\userquake_example1.txt --map-type JAPAN_4096
```

![output](https://user-images.githubusercontent.com/1283492/132971101-00e840dd-af33-48d8-8836-bfbfcdd1e727.png)