### PR TITLE
Make userquake aggregator thread-safe

### DIFF
--- a/Client/App/Userquake/Aggregator.cs
+++ b/Client/App/Userquake/Aggregator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -19,7 +20,7 @@ namespace Client.App.Userquake
         public IUserquakeEvaluation Evaluation { get; private set; }
         public bool IsDetecting { get; private set; }
 
-        ICollection<Userquake> userquakes;
+        BlockingCollection<Userquake> userquakes;
 
         public IUserquakeEvaluation EvaluationAt(DateTime at)
         {
@@ -41,14 +42,14 @@ namespace Client.App.Userquake
             // リセット、追加
             if (UserquakeIsOver(at))
             {
-                userquakes = new LinkedList<Userquake>();
+                userquakes = new();
                 IsDetecting = false;
                 Evaluation = null;
             }
             userquakes.Add(new Userquake() { At = at, AreaCode = areaCode });
 
             // 評価
-            var evaluation = Evaluate(userquakes, areaPeers);
+            var evaluation = Evaluate(userquakes.ToArray(), areaPeers);
             Evaluation = evaluation;
             if (evaluation == null || evaluation.ConfidenceLevel < 3)
             {
@@ -76,7 +77,7 @@ namespace Client.App.Userquake
             }
         }
 
-        IUserquakeEvaluation Evaluate(ICollection<Userquake> userquakes, IReadOnlyDictionary<string, int> areaPeers)
+        IUserquakeEvaluation Evaluate(IReadOnlyCollection<Userquake> userquakes, IReadOnlyDictionary<string, int> areaPeers)
         {
             var confidenceValue = new double[] { 0, 0.97015, 0.96774, 0.97024, 0.98052 };
 

--- a/ClientTest/App/Userquake/AggregatorMultithreadTest.cs
+++ b/ClientTest/App/Userquake/AggregatorMultithreadTest.cs
@@ -1,0 +1,54 @@
+﻿using Client.App.Userquake;
+
+using NUnit.Framework;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClientTest.App.Userquake
+{
+    [TestFixture]
+    class AggregatorMultithreadTest
+    {
+        Aggregator aggregator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            aggregator = new();
+        }
+
+        [TestCase]
+        public void MultithreadTest()
+        {
+            // ピア分布図データを用意
+            var areaPeers = new Dictionary<string, int>()
+            {
+                { "010", 10 },
+                { "015", 10 },
+            };
+
+            Action addUserquakes = () =>
+            {
+                var r = new Random();
+                var sw = new Stopwatch();
+                sw.Start();
+                while (sw.ElapsedMilliseconds < 5000)
+                {
+                    aggregator.AddUserquake(DateTime.Now, "010", areaPeers);
+                    aggregator.AddUserquake(DateTime.Now, "015", areaPeers);
+                    Thread.Sleep(r.Next(1, 10));
+                }
+            };
+
+            // マルチスレッドで地震感知情報のイベントを発火
+            Parallel.Invoke(Enumerable.Repeat(addUserquakes, 10).ToArray());
+            Thread.Sleep(5500);
+        }
+    }
+}

--- a/ClientTest/App/Userquake/AggregatorMultithreadTest.cs
+++ b/ClientTest/App/Userquake/AggregatorMultithreadTest.cs
@@ -33,8 +33,11 @@ namespace ClientTest.App.Userquake
                 { "015", 10 },
             };
 
+            var count = 0;
+
             Action addUserquakes = () =>
             {
+                var actionCount = 0;
                 var r = new Random();
                 var sw = new Stopwatch();
                 sw.Start();
@@ -42,13 +45,16 @@ namespace ClientTest.App.Userquake
                 {
                     aggregator.AddUserquake(DateTime.Now, "010", areaPeers);
                     aggregator.AddUserquake(DateTime.Now, "015", areaPeers);
-                    Thread.Sleep(r.Next(1, 10));
+                    actionCount += 2;
                 }
+                Interlocked.Add(ref count, actionCount);
             };
 
             // マルチスレッドで地震感知情報のイベントを発火
             Parallel.Invoke(Enumerable.Repeat(addUserquakes, 10).ToArray());
-            Thread.Sleep(5500);
+
+            Assert.AreEqual(count, aggregator.Evaluation.Count);
+            Console.WriteLine($"Count: {count}");
         }
     }
 }


### PR DESCRIPTION
See:

- [並列プログラミング向けのデータ構造 \| Microsoft Docs](https://docs.microsoft.com/ja-jp/dotnet/standard/parallel-programming/data-structures-for-parallel-programming)
- [スレッド セーフなコレクション \| Microsoft Docs](https://docs.microsoft.com/ja-jp/dotnet/standard/collections/thread-safe/)