### PR TITLE
Use GitHub Actions instead of AppVeyor

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -6,11 +6,22 @@ on:
 
 # See: https://docs.microsoft.com/ja-jp/dotnet/devops/dotnet-test-github-action
 #      https://docs.microsoft.com/ja-jp/aspnet/core/host-and-deploy/visual-studio-publish-profiles?view=aspnetcore-5.0#folder-publish-example
+#      https://github.com/actions/cache/blob/main/examples.md#c---nuget
+
+env:
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
 jobs:
   on-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Setup .NET 5.0
         uses: actions/setup-dotnet@v1
         with:
@@ -23,6 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Setup .NET 5.0
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -1,0 +1,34 @@
+name: dotnet build and test
+
+on:
+  - push
+  - pull_request
+
+# See: https://docs.microsoft.com/ja-jp/dotnet/devops/dotnet-test-github-action
+#      https://docs.microsoft.com/ja-jp/aspnet/core/host-and-deploy/visual-studio-publish-profiles?view=aspnetcore-5.0#folder-publish-example
+jobs:
+  on-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+      - name: Build
+        run: dotnet build
+      - name: Test
+        run: dotnet test
+  on-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+      - name: Build
+        run: dotnet build --configuration DebugExcludeWPF
+      - name: Test
+        run: dotnet test --configuration DebugExcludeWPF
+


### PR DESCRIPTION
1.7x faster

> 8 minutes ago in 4 min 11 sec  
> https://ci.appveyor.com/project/typewriter/epsp-peer-cs/builds/42642224

> Total duration 2m 27s
> https://github.com/p2pquake/epsp-peer-cs/actions/runs/1881601830