### PR TITLE
Remove unnecessary exception handler

### DIFF
--- a/WpfClient/Program.cs
+++ b/WpfClient/Program.cs
@@ -95,7 +95,6 @@ namespace WpfClient
             app.InitializeComponent();
             app.SessionEnding += App_SessionEnding;
             app.DispatcherUnhandledException += App_DispatcherUnhandledException;
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             app.Run();
         }
 
@@ -110,11 +109,6 @@ namespace WpfClient
                 o.Environment = "release";
 #endif
             });
-        }
-
-        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-        {
-            SentrySdk.CaptureException((Exception)e.ExceptionObject);
         }
 
         private static void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)


### PR DESCRIPTION
Sentry がデフォルトでハンドラを設定してくれていて、自前でハンドラを設定する必要はなかった。 UnobservedTaskException が捕捉されているのもデフォルトでハンドラがあるため。

https://github.com/getsentry/sentry-dotnet/blob/f4af8dd401158417c4aedaaaaf7fc5f4dd8f07ac/src/Sentry/SentryOptions.cs#L602