### PR TITLE
Use Mono.Nat instead of Open.NAT to eliminate unhandled exceptions

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.14" />
-    <PackageReference Include="Open.Nat" Version="2.1.0" />
+    <PackageReference Include="Mono.Nat" Version="3.0.3" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix #252 