### PR TITLE
Fix version not showing

### DIFF
--- a/WpfClient/StatusViewModel.cs
+++ b/WpfClient/StatusViewModel.cs
@@ -85,8 +85,7 @@ namespace WpfClient
         {
             get
             {
-                var asm = Assembly.GetExecutingAssembly();
-                var info = FileVersionInfo.GetVersionInfo(asm.Location);
+                var info = FileVersionInfo.GetVersionInfo(Environment.ProcessPath);
                 return $"P2P地震情報 Beta{info.ProductMinorPart/10.0:0.0}(Rev{info.ProductBuildPart:00})";
             }
         }


### PR DESCRIPTION
> Assembly.Location | Returns an empty string.
> 
> To find the file name of the executable, use the first element of [Environment.GetCommandLineArgs()](https://docs.microsoft.com/en-us/dotnet/api/system.environment.getcommandlineargs#system-environment-getcommandlineargs), or starting with .NET 6, use the file name from [ProcessPath](https://docs.microsoft.com/en-us/dotnet/api/system.environment.processpath#system-environment-processpath).
> 
> [Create a single file for application deployment \- \.NET \| Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#api-incompatibility)



before: ![image](https://user-images.githubusercontent.com/1283492/186198150-bd789fb1-93bb-4211-900e-b934d04a34f9.png)
after: ![image](https://user-images.githubusercontent.com/1283492/186198290-d2faffc1-46b2-4029-b13e-25ff39e9b57d.png)
