### PR TITLE
Improve map drawing performance

### DIFF
--- a/Map/Controller/MapDrawer.cs
+++ b/Map/Controller/MapDrawer.cs
@@ -155,10 +155,10 @@ namespace Map.Controller
                 ));
 
                 var margin = MapType == MapType.JAPAN_1024 ? 240 : 480;
-                var l = new int[] { 0, new int[] { lt.X, rb.X - margin }.Min() }.Max();
-                var t = new int[] { 0, new int[] { lt.Y, rb.Y - margin }.Min() }.Max();
-                var r = new int[] { image.Width, new int[] { rb.X, lt.X + margin }.Max() }.Min();
-                var b = new int[] { image.Height, new int[] { rb.Y, lt.Y + margin }.Max() }.Min();
+                var l = Math.Max(0, Math.Min(lt.X, rb.X - margin));
+                var t = Math.Max(0, Math.Min(lt.Y, rb.Y - margin));
+                var r = Math.Min(image.Width, Math.Max(rb.X, lt.X + margin));
+                var b = Math.Min(image.Height, Math.Max(rb.Y, lt.Y + margin));
 
                 if (PreferedAspectRatio > 0)
                 {
@@ -167,14 +167,14 @@ namespace Map.Controller
                     {
                         // 横を増やす
                         var appendWidth = (b - t) * PreferedAspectRatio - (r - l);
-                        l = new int[] { 0, (int)(l - appendWidth / 2) }.Max();
-                        r = new int[] { image.Width, (int)(r + appendWidth / 2) }.Min();
+                        l = Math.Max(0, (int)(l - appendWidth / 2));
+                        r = Math.Min(image.Width, (int)(r + appendWidth / 2));
                     } else
                     {
                         // 縦を増やす
                         var appendHeight = (r - l) / PreferedAspectRatio - (b - t);
-                        t = new int[] { 0, (int)(t - appendHeight / 2) }.Max();
-                        b = new int[] { image.Height, (int)(b + appendHeight / 2) }.Min();
+                        t = Math.Max(0, (int)(t - appendHeight / 2));
+                        b = Math.Min(image.Height, (int)(b + appendHeight / 2));
                     }
                 }
 

--- a/Map/Controller/MapDrawer.cs
+++ b/Map/Controller/MapDrawer.cs
@@ -44,7 +44,7 @@ namespace Map.Controller
         {
             // 画像ロード
             var mapData = MapLoader.Load(MapType);
-            var image = mapData.Image;
+            var image = mapData.Image.Clone(x => { });
 
             // 描画対象を準備 ----
             var drawers = new List<AbstractDrawer>();

--- a/Map/Model/AreapeersDrawer.cs
+++ b/Map/Model/AreapeersDrawer.cs
@@ -78,28 +78,21 @@ namespace Map.Model
                 }
 
                 var coordinatesArray = uqAreas.GetMultiPolygon(area.Areacode);
+                var paths = coordinatesArray.Select(coordinates => new PathBuilder().AddLines(coordinates.Select(e =>
+                {
+                    var pos = trans.Geo2FloatPixel(e);
+                    return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
+                })).Build()).ToArray();
 
                 // 輪郭線
-                foreach (var coordinates in coordinatesArray)
+                foreach (var path in paths)
                 {
-                    var path = new PathBuilder().AddLines(coordinates.Select(e =>
-                    {
-                        var pos = trans.Geo2FloatPixel(e);
-                        return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
-                    })).Build();
-
                     Image.Mutate(x => x.Draw(new Pen(Color.Black.WithAlpha(0.25f), 3), path));
                 }
 
                 // 塗りつぶし
-                foreach (var coordinates in coordinatesArray)
+                foreach (var path in paths)
                 {
-                    var path = new PathBuilder().AddLines(coordinates.Select(e =>
-                    {
-                        var pos = trans.Geo2FloatPixel(e);
-                        return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
-                    })).Build();
-
                     Image.Mutate(x => x.Fill(Color.FromRgb(160, 224, 255), path));
                 }
             }

--- a/Map/Model/AreapeersDrawer.cs
+++ b/Map/Model/AreapeersDrawer.cs
@@ -17,6 +17,23 @@ namespace Map.Model
 
     class AreapeersDrawer : AbstractDrawer
     {
+        static readonly Lazy<FontFamily> s_fontFamily = new Lazy<FontFamily>(() =>
+        {
+            using var fontStream = new MemoryStream(FontResource.RobotoMono_Bold);
+            var collection = new FontCollection();
+            return collection.Add(fontStream);
+        });
+        static readonly Dictionary<int, Font> s_mappingDrawSizeToFont = new Dictionary<int, Font>();
+        static Font GetFont(int drawSize)
+        {
+            if (!s_mappingDrawSizeToFont.TryGetValue(drawSize, out var font))
+            {
+                font = s_fontFamily.Value.CreateFont(drawSize, FontStyle.Bold);
+                s_mappingDrawSizeToFont.Add(drawSize, font);
+            }
+            return font;
+        }
+
         public IList<Areapeer> Areapeers { get; init; }
 
         public override LTRBCoordinate CalcDrawLTRB()
@@ -88,10 +105,7 @@ namespace Map.Model
             }
 
             // 文字描画
-            using var fontStream = new MemoryStream(FontResource.RobotoMono_Bold);
-            var collection = new FontCollection();
-            var family = collection.Add(fontStream);
-            var font = family.CreateFont(drawSize, FontStyle.Bold);
+            var font = GetFont(drawSize);
             var rendererOptions = new TextOptions(font);
 
             foreach (var area in Areapeers) {

--- a/Map/Model/EEWDrawer.cs
+++ b/Map/Model/EEWDrawer.cs
@@ -69,29 +69,24 @@ namespace Map.Model
                 }
 
                 var coordinatesArray = eewAreas.GetMultiPolygon(point.Areacode);
-                var lineSize = Image.Width > 1024 ? 8 : 4;
-
-                // 輪郭線
-                foreach (var coordinates in coordinatesArray)
-                {
-                    var path = new PathBuilder().AddLines(coordinates.Select(e =>
+                var paths = coordinatesArray.Select(coordinates => 
+                    new PathBuilder().AddLines(coordinates.Select(e =>
                     {
                         var pos = trans.Geo2FloatPixel(e);
                         return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
-                    })).Build();
+                    })).Build()
+                ).ToArray();
+                var lineSize = Image.Width > 1024 ? 8 : 4;
 
+                // 輪郭線
+                foreach (var path in paths)
+                {
                     Image.Mutate(x => x.Draw(new Pen(Color.DarkOrange.WithAlpha(0.8f), lineSize), path));
                 }
 
                 // 塗りつぶし
-                foreach (var coordinates in coordinatesArray)
+                foreach (var path in paths)
                 {
-                    var path = new PathBuilder().AddLines(coordinates.Select(e =>
-                    {
-                        var pos = trans.Geo2FloatPixel(e);
-                        return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
-                    })).Build();
-
                     Image.Mutate(x => x.Fill(Color.Orange.WithAlpha(0.95f), path));
                 }
             }

--- a/Map/Model/HypocenterDrawer.cs
+++ b/Map/Model/HypocenterDrawer.cs
@@ -21,6 +21,8 @@ namespace Map.Model
             return new LTRBCoordinate(Longitude, Latitude, Longitude, Latitude);
         }
 
+        static readonly List<int> lineParams = new List<int>() { -1, 1 };
+
         public override void Draw()
         {
             var transformation = new Transformation
@@ -35,7 +37,7 @@ namespace Map.Model
             var size = 6;
             var thickness = 2;
 
-            new int[] { -1, 1 }.ToList().ForEach(v =>
+            lineParams.ForEach(v =>
             {
                 var path = new Path(new LinearLineSegment(
                     new SixLabors.ImageSharp.PointF(pos.X - size, pos.Y - (size * v)),

--- a/Map/Model/MapLoader.cs
+++ b/Map/Model/MapLoader.cs
@@ -29,15 +29,22 @@ namespace Map.Model
 
     public static class MapLoader
     {
+        static Dictionary<MapType, MapData> _cache = new Dictionary<MapType, MapData>();
+
         /// <summary>
         /// 地図の画像データと緯度経度範囲情報を読み込みます。
         /// <para>type = MapType.JAPAN_8192 でメモリを 300 MB 程度消費します。</para>
         /// </summary>
         public static MapData Load(MapType type)
         {
-            var (image, isMercator) = ImageFromResource(type);
-            var ltrb = LTRB(type);
-            return new MapData(image, ltrb, isMercator);
+            if (!_cache.TryGetValue(type, out var mapData))
+            {
+                var (image, isMercator) = ImageFromResource(type);
+                var ltrb = LTRB(type);
+                mapData = new MapData(image, ltrb, isMercator);
+                _cache.Add(type, mapData);
+            }
+            return mapData;
         }
 
         private static (Image image, bool isMercator) ImageFromResource(MapType type)

--- a/Map/Model/ObservationAreasDrawer.cs
+++ b/Map/Model/ObservationAreasDrawer.cs
@@ -21,22 +21,22 @@ namespace Map.Model
             return null;
         }
 
+        static readonly Dictionary<int, Color> colorMap = new Dictionary<int, Color>
+        {
+            { 10, new Color(new Rgb24(160, 224, 255)) },
+            { 20, new Color(new Rgb24(160, 208, 255)) },
+            { 30, new Color(new Rgb24(176, 192, 255)) },
+            { 40, new Color(new Rgb24(112, 224, 128)) },
+            { 45, new Color(new Rgb24(128, 192,   0)) },
+            { 46, new Color(new Rgb24(128, 192,   0)) },
+            { 50, new Color(new Rgb24(240, 128,   0)) },
+            { 55, new Color(new Rgb24(208, 112,   0)) },
+            { 60, new Color(new Rgb24(224,  32,  32)) },
+            { 70, new Color(new Rgb24(160,   0,  32)) }
+        };
+
         public override void Draw()
         {
-            var colorMap = new Dictionary<int, Color>
-            {
-                { 10, new Color(new Rgb24(160, 224, 255)) },
-                { 20, new Color(new Rgb24(160, 208, 255)) },
-                { 30, new Color(new Rgb24(176, 192, 255)) },
-                { 40, new Color(new Rgb24(112, 224, 128)) },
-                { 45, new Color(new Rgb24(128, 192, 0)) },
-                { 46, new Color(new Rgb24(128, 192, 0)) },
-                { 50, new Color(new Rgb24(240, 128, 0)) },
-                { 55, new Color(new Rgb24(208, 112, 0)) },
-                { 60, new Color(new Rgb24(224, 32, 32)) },
-                { 70, new Color(new Rgb24(160, 0, 32)) }
-            };
-
             var areas = ObservationAreas.Instance;
 
             var trans = new Transformation

--- a/Map/Model/ObservationPointsDrawer.cs
+++ b/Map/Model/ObservationPointsDrawer.cs
@@ -38,39 +38,40 @@ namespace Map.Model
             );
         }
 
+        static readonly Dictionary<int, Image> scaleImages = new Dictionary<int, Image>()
+        {
+            { 10, Image.Load(Map.ImageResource.Scale10) },
+            { 20, Image.Load(Map.ImageResource.Scale20) },
+            { 30, Image.Load(Map.ImageResource.Scale30) },
+            { 40, Image.Load(Map.ImageResource.Scale40) },
+            { 45, Image.Load(Map.ImageResource.Scale45) },
+            { 46, Image.Load(Map.ImageResource.Scale46) },
+            { 50, Image.Load(Map.ImageResource.Scale50) },
+            { 55, Image.Load(Map.ImageResource.Scale55) },
+            { 60, Image.Load(Map.ImageResource.Scale60) },
+            { 70, Image.Load(Map.ImageResource.Scale70) },
+        };
+
+        static readonly Dictionary<int, Image> scaleAreaImages = new Dictionary<int, Image>()
+        {
+            { 10, Image.Load(Map.ImageResource.Scale10) },
+            { 20, Image.Load(Map.ImageResource.Scale20) },
+            { 30, Image.Load(Map.ImageResource.Scale30) },
+            { 40, Image.Load(Map.ImageResource.Scale40) },
+            { 45, Image.Load(Map.ImageResource.Scale45) },
+            { 46, Image.Load(Map.ImageResource.Scale46) },
+            { 50, Image.Load(Map.ImageResource.Scale50) },
+            { 55, Image.Load(Map.ImageResource.Scale55) },
+            { 60, Image.Load(Map.ImageResource.Scale60) },
+            { 70, Image.Load(Map.ImageResource.Scale70) },
+        };
+
         public override void Draw()
         {
             var drawPointSize = Image.Width > 1024 ? 16 : 12;
             var drawAreaSize = Image.Width > 1024 ? 24 : 16;
 
             var stations = Stations.Instance;
-            // XXX: かしこくない実装方法
-            var scaleImages = new Dictionary<int, Image>() {
-                { 10, Image.Load(new MemoryStream(Map.ImageResource.Scale10)) },
-                { 20, Image.Load(new MemoryStream(Map.ImageResource.Scale20)) },
-                { 30, Image.Load(new MemoryStream(Map.ImageResource.Scale30)) },
-                { 40, Image.Load(new MemoryStream(Map.ImageResource.Scale40)) },
-                { 45, Image.Load(new MemoryStream(Map.ImageResource.Scale45)) },
-                { 46, Image.Load(new MemoryStream(Map.ImageResource.Scale46)) },
-                { 50, Image.Load(new MemoryStream(Map.ImageResource.Scale50)) },
-                { 55, Image.Load(new MemoryStream(Map.ImageResource.Scale55)) },
-                { 60, Image.Load(new MemoryStream(Map.ImageResource.Scale60)) },
-                { 70, Image.Load(new MemoryStream(Map.ImageResource.Scale70)) },
-            };
-            scaleImages.Values.ToList().ForEach(e => e.Mutate(x => x.Resize(drawPointSize, drawPointSize)));
-            var scaleAreaImages = new Dictionary<int, Image>() {
-                { 10, Image.Load(new MemoryStream(Map.ImageResource.Scale10)) },
-                { 20, Image.Load(new MemoryStream(Map.ImageResource.Scale20)) },
-                { 30, Image.Load(new MemoryStream(Map.ImageResource.Scale30)) },
-                { 40, Image.Load(new MemoryStream(Map.ImageResource.Scale40)) },
-                { 45, Image.Load(new MemoryStream(Map.ImageResource.Scale45)) },
-                { 46, Image.Load(new MemoryStream(Map.ImageResource.Scale46)) },
-                { 50, Image.Load(new MemoryStream(Map.ImageResource.Scale50)) },
-                { 55, Image.Load(new MemoryStream(Map.ImageResource.Scale55)) },
-                { 60, Image.Load(new MemoryStream(Map.ImageResource.Scale60)) },
-                { 70, Image.Load(new MemoryStream(Map.ImageResource.Scale70)) },
-            };
-            scaleAreaImages.Values.ToList().ForEach(e => e.Mutate(x => x.Resize(drawAreaSize, drawAreaSize)));
 
             var trans = new Transformation
             {
@@ -89,7 +90,9 @@ namespace Map.Model
                 }
 
                 var drawSize = areas.GetArea(point.Name) == null ? drawPointSize : drawAreaSize;
-                var scaleImage = areas.GetArea(point.Name) == null ? scaleImages[point.Scale] : scaleAreaImages[point.Scale];
+                var scaleImage = areas.GetArea(point.Name) == null
+                    ? scaleImages[point.Scale].Clone(x => x.Resize(drawPointSize, drawPointSize))
+                    : scaleAreaImages[point.Scale].Clone(x => x.Resize(drawAreaSize, drawAreaSize));
 
                 var pos = trans.Geo2Pixel(coordinate);
                 var rect = new Rectangle(pos.X - (drawSize / 2 + 1), pos.Y - (drawSize / 2 + 1), drawSize + 2, drawSize + 2);

--- a/Map/Model/TsunamiAreasDrawer.cs
+++ b/Map/Model/TsunamiAreasDrawer.cs
@@ -48,15 +48,15 @@ namespace Map.Model
             );
         }
 
+        static readonly Dictionary<TsunamiCategory, Color> colorMap = new Dictionary<TsunamiCategory, Color>
+        {
+            { TsunamiCategory.MajorWarning, new Color(new Rgb24(200,   0, 255)) },
+            { TsunamiCategory.Warning     , new Color(new Rgb24(255,  40,   0)) },
+            { TsunamiCategory.Advisory    , new Color(new Rgb24(250, 245,   0)) },
+        };
+
         public override void Draw()
         {
-            var colorMap = new Dictionary<TsunamiCategory, Color>
-            {
-                { TsunamiCategory.MajorWarning, new Color(new Rgb24(200, 0, 255)) },
-                { TsunamiCategory.Warning, new Color(new Rgb24(255, 40, 0)) },
-                { TsunamiCategory.Advisory, new Color(new Rgb24(250, 245, 0)) },
-            };
-
             var areas = TsunamiAreas.Instance;
 
             var trans = new Transformation

--- a/Map/Model/UserquakeDrawer.cs
+++ b/Map/Model/UserquakeDrawer.cs
@@ -38,21 +38,21 @@ namespace Map.Model
             );
         }
 
+        static readonly Dictionary<string, Image> uqImages = new Dictionary<string, Image>()
+        {
+            { "A", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceA)) },
+            { "B", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceB)) },
+            { "C", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceC)) },
+            { "D", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceD)) },
+            { "E", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceE)) },
+            { "F", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceF)) },
+        };
+
         public override void Draw()
         {
             var drawSize = Image.Width > 1024 ? 24 : 12;
 
             var uqAreas = UserquakeAreas.Instance;
-            var uqImages = new Dictionary<string, Image>()
-            {
-                { "A", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceA)) },
-                { "B", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceB)) },
-                { "C", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceC)) },
-                { "D", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceD)) },
-                { "E", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceE)) },
-                { "F", Image.Load(new MemoryStream(Map.ImageResource.ConfidenceF)) },
-            };
-            uqImages.Values.ToList().ForEach(e => e.Mutate(x => x.Resize(drawSize, drawSize)));
 
             var trans = new Transformation
             {
@@ -101,7 +101,7 @@ namespace Map.Model
                 var coordinate = uqAreas.Get(point.Areacode);
                 var pos = trans.Geo2Pixel(coordinate);
                 var rect = new Rectangle(pos.X - (drawSize / 2 + 1), pos.Y - (drawSize / 2 + 1), drawSize + 2, drawSize + 2);
-                Image.Mutate(x => x.DrawImage(uqImages[ConvConfidence(point.Confidence)], new Point(pos.X - (drawSize / 2), pos.Y - (drawSize / 2)), 1));
+                Image.Mutate(x => x.DrawImage(uqImages[ConvConfidence(point.Confidence)].Clone(x => x.Resize(drawSize, drawSize)), new Point(pos.X - (drawSize / 2), pos.Y - (drawSize / 2)), 1));
             }
         }
 

--- a/Map/Model/UserquakeDrawer.cs
+++ b/Map/Model/UserquakeDrawer.cs
@@ -72,28 +72,21 @@ namespace Map.Model
                 }
 
                 var coordinatesArray = uqAreas.GetMultiPolygon(point.Areacode);
+                var paths = coordinatesArray.Select(coordinates => new PathBuilder().AddLines(coordinates.Select(e =>
+                {
+                    var pos = trans.Geo2FloatPixel(e);
+                    return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
+                })).Build()).ToArray();
 
                 // 輪郭線
-                foreach (var coordinates in coordinatesArray)
+                foreach (var path in paths)
                 {
-                    var path = new PathBuilder().AddLines(coordinates.Select(e =>
-                    {
-                        var pos = trans.Geo2FloatPixel(e);
-                        return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
-                    })).Build();
-
                     Image.Mutate(x => x.Draw(new Pen(Color.Gray.WithAlpha(0.5f), 2), path));
                 }
 
                 // 塗りつぶし
-                foreach (var coordinates in coordinatesArray)
+                foreach (var path in paths)
                 {
-                    var path = new PathBuilder().AddLines(coordinates.Select(e =>
-                    {
-                        var pos = trans.Geo2FloatPixel(e);
-                        return new SixLabors.ImageSharp.PointF(pos.X, pos.Y);
-                    })).Build();
-
                     Image.Mutate(x => x.Fill(ConvConfidenceColor(point.Confidence).WithAlpha(0.95f), path));
                 }
             }


### PR DESCRIPTION
地図描画の性能を改善しました。

具体的には…
- 二つの数値だけを比較する場合、`Enumerable.Min()` と `Enumerable.Max()` を `Math.Min()` と `Math.Max()` に変更しました。
- 地図の画像やフォントを再び読み込まないためにメモリに保持する。
- 輪郭線と塗りつぶしを描画する場合、事前に全ての `IPath` を作成する。（変更前は二つのループから二回作成した）
- メソッドの中にあるコレクションは、内容が常に変わらないなら、メソッドの外に移動、`static readonly` のフィールドに変更されました。

（日本人ではないので、単語や文法に間違いがあったら申し訳ございません…）